### PR TITLE
DEV: Exclude wandb from being detected as first party

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -95,8 +95,8 @@ When creating a new repository from this template, these are the steps to follow
 
     .. code-block:: bash
 
-        sed -i "s/template_experiment/$PROJ_DIRN/" "$PROJ_DIRN"/*.py setup.py slurm/*.slrm .pre-commit-config.yaml
-        sed -i "s/template-experiment/$PROJ_HYPH/" "$PROJ_DIRN"/*.py setup.py slurm/*.slrm .pre-commit-config.yaml
+        sed -i "s/template_experiment/$PROJ_DIRN/" "$PROJ_DIRN"/*.py setup.py pyproject.toml slurm/*.slrm .pre-commit-config.yaml
+        sed -i "s/template-experiment/$PROJ_HYPH/" "$PROJ_DIRN"/*.py setup.py pyproject.toml slurm/*.slrm .pre-commit-config.yaml
 
     Which will make changes in the following places.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,3 +8,4 @@ target-version = ["py38"]
 
 [tool.isort]
 src_paths = ["template_experiment"]
+known_first_party = ["template_experiment"]


### PR DESCRIPTION
Adding src_paths (e77745f) is insufficient, so we need to declare known_first_party too. This prevents a local directory being confused for first party code by isort when it is imported, in particular wandb.

We also needed to add an instruction to replace this when initializing a repo from the template.